### PR TITLE
Add `diagonal`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,10 +6,12 @@ version = "0.2.1"
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"
 DerivableInterfaces = "6c5e35bf-e59e-4898-b73c-732dcc4ba65f"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 SparseArraysBase = "0d5efcca-f356-4864-8770-e1ed8d78f208"
 
 [compat]
 ArrayLayouts = "1.10.4"
 DerivableInterfaces = "0.3.7"
+LinearAlgebra = "1.10.0"
 SparseArraysBase = "0.2.1"
 julia = "1.10"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DiagonalArrays"
 uuid = "74fd4be6-21e2-4f6f-823a-4360d37c7a77"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
-version = "0.2.1"
+version = "0.2.2"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -14,7 +14,7 @@ makedocs(;
     edit_link="main",
     assets=String[],
   ),
-  pages=["Home" => "index.md"],
+  pages=["Home" => "index.md", "Library" => "library.md"],
 )
 
 deploydocs(;

--- a/docs/src/library.md
+++ b/docs/src/library.md
@@ -1,0 +1,5 @@
+# Library
+
+```@autodocs
+Modules = [DiagonalArrays]
+```

--- a/src/diaginterface/diaginterface.jl
+++ b/src/diaginterface/diaginterface.jl
@@ -1,5 +1,7 @@
 # TODO: Turn these into `@interface ::AbstractDiagonalArrayInterface` functions.
 
+using LinearAlgebra: LinearAlgebra
+
 diaglength(a::AbstractArray{<:Any,0}) = 1
 
 function diaglength(a::AbstractArray)

--- a/src/diaginterface/diaginterface.jl
+++ b/src/diaginterface/diaginterface.jl
@@ -92,19 +92,10 @@ function setdiagindices!(a::AbstractArray, v, i::Colon)
 end
 
 """
-    diagonal(v::AbstractVector, [axes]) -> AbstractMatrix
+    diagonal(v::AbstractVector) -> AbstractMatrix
 
-Return a diagonal matrix from a vector `v`, optionally providing the `axes` of the resulting matrix.
-This is an extension of `LinearAlgebra.Diagonal`, designed to avoid the implication of the output type,
-as well as allowing the option of specifying the `axes`.
+Return a diagonal matrix from a vector `v`.
+This is an extension of `LinearAlgebra.Diagonal`, designed to avoid the implication of the output type.
 Defaults to `Diagonal(v)`.
 """
-function diagonal(v::AbstractVector)
-  ax = axes(v, 1) # Base.axes1 is private
-  return diagonal(v, (ax, ax))
-end
-function diagonal(v::AbstractVector, ax)
-  vax = axes(v, 1)
-  ax == (vax, vax) || throw(ArgumentError(lazy"Cannot create a `Diagonal` with axes $ax"))
-  return LinearAlgebra.Diagonal(v)
-end
+diagonal(v::AbstractVector) = LinearAlgebra.Diagonal(v)

--- a/src/diaginterface/diaginterface.jl
+++ b/src/diaginterface/diaginterface.jl
@@ -92,9 +92,19 @@ function setdiagindices!(a::AbstractArray, v, i::Colon)
 end
 
 """
-    diagonal(v::AbstractVector) -> AbstractMatrix
+    diagonal(v::AbstractVector, [axes]) -> AbstractMatrix
 
-Return a diagonal matrix from a vector `v`. This is a replacement of `LinearAlgebra.Diagonal`
-that does not imply an output type. Defaults to `Diagonal(v)`.
+Return a diagonal matrix from a vector `v`, optionally providing the `axes` of the resulting matrix.
+This is an extension of `LinearAlgebra.Diagonal`, designed to avoid the implication of the output type,
+as well as allowing the option of specifying the `axes`.
+Defaults to `Diagonal(v)`.
 """
-diagonal(A::AbstractVector) = LinearAlgebra.Diagonal(A)
+function diagonal(v::AbstractVector)
+  ax = axes(v, 1) # Base.axes1 is private
+  return diagonal(v, (ax, ax))
+end
+function diagonal(v::AbstractVector, ax)
+  vax = axes(v, 1)
+  ax == (vax, vax) || throw(ArgumentError(lazy"Cannot create a `Diagonal` with axes $ax"))
+  return LinearAlgebra.Diagonal(v)
+end

--- a/src/diaginterface/diaginterface.jl
+++ b/src/diaginterface/diaginterface.jl
@@ -88,3 +88,11 @@ function setdiagindices!(a::AbstractArray, v, i::Colon)
   diagview(a) .= v
   return a
 end
+
+"""
+  diagonal(v::AbstractVector) -> AbstractMatrix
+
+Return a diagonal matrix from a vector `v`. This is a replacement of `LinearAlgebra.Diagonal`
+that does not imply an output type. Defaults to `Diagonal(v)`.
+"""
+diagonal(A::AbstractVector) = LinearAlgebra.Diagonal(A)

--- a/src/diaginterface/diaginterface.jl
+++ b/src/diaginterface/diaginterface.jl
@@ -90,7 +90,7 @@ function setdiagindices!(a::AbstractArray, v, i::Colon)
 end
 
 """
-  diagonal(v::AbstractVector) -> AbstractMatrix
+    diagonal(v::AbstractVector) -> AbstractMatrix
 
 Return a diagonal matrix from a vector `v`. This is a replacement of `LinearAlgebra.Diagonal`
 that does not imply an output type. Defaults to `Diagonal(v)`.

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,6 +1,7 @@
 [deps]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 DiagonalArrays = "74fd4be6-21e2-4f6f-823a-4360d37c7a77"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SparseArraysBase = "0d5efcca-f356-4864-8770-e1ed8d78f208"
 Suppressor = "fd094767-a336-5f1f-9728-57cf17d0bbfb"

--- a/test/test_basics.jl
+++ b/test/test_basics.jl
@@ -1,6 +1,8 @@
-using Test: @test, @testset, @test_broken
-using DiagonalArrays: DiagonalArrays, DiagonalArray, DiagonalMatrix, diaglength
+using Test: @test, @testset, @test_broken, @inferred
+using DiagonalArrays: DiagonalArrays, DiagonalArray, DiagonalMatrix, diaglength, diagonal
 using SparseArraysBase: SparseArrayDOK, storedlength
+using LinearAlgebra: Diagonal
+
 @testset "Test DiagonalArrays" begin
   @testset "DiagonalArray (eltype=$elt)" for elt in (
     Float32, Float64, Complex{Float32}, Complex{Float64}
@@ -45,6 +47,10 @@ using SparseArraysBase: SparseArrayDOK, storedlength
       # TODO: Make this work with `ArrayLayouts`.
       @test storedlength(a_dest) == 2
       @test a_dest isa SparseArrayDOK{elt,2}
+    end
+    @testset "diagonal" begin
+      @test @inferred(diagonal(rand(2))) isa AbstractMatrix
+      @test diagonal(zeros(Int, 2)) isa Diagonal
     end
   end
 end


### PR DESCRIPTION
This adds a utility entrance-point to turn a vector into a diagonal matrix, without implying the return type. Specifically, it adds `diagonal`, which relates to `Diagonal` in the same way that `adjoint` relates to `Adjoint`.
The main purpose is to have the ability to write generic code, without having to force everything to be of type `Diagonal`.