### PR TITLE
Upgrade to DerivableInterfaces v0.4

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DiagonalArrays"
 uuid = "74fd4be6-21e2-4f6f-823a-4360d37c7a77"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
-version = "0.3.1"
+version = "0.3.2"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"
@@ -12,7 +12,7 @@ SparseArraysBase = "0d5efcca-f356-4864-8770-e1ed8d78f208"
 
 [compat]
 ArrayLayouts = "1.10.4"
-DerivableInterfaces = "0.3.7"
+DerivableInterfaces = "0.4"
 FillArrays = "1.13.0"
 LinearAlgebra = "1.10.0"
 SparseArraysBase = "0.5"


### PR DESCRIPTION
Update for https://github.com/ITensor/DerivableInterfaces.jl/pull/18, depends on https://github.com/ITensor/SparseArraysBase.jl/pull/47.